### PR TITLE
Added support for WC 2.1 notices #22

### DIFF
--- a/coinbase-woocommerce.php
+++ b/coinbase-woocommerce.php
@@ -203,7 +203,11 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
 				$api_secret = $this->get_option('apiSecret');
 
 				if ($api_key == '' || $api_secret == '') {
-					$woocommerce->add_error(__('Sorry, but there was an error processing your order. Please try again or try a different payment method. (plugin not configured)', 'coinbase-woocommerce'));
+					if ( version_compare( $woocommerce->version, '2.1', '>=' ) ) { 
+						wc_add_notice(__('Sorry, but there was an error processing your order. Please try again or try a different payment method. (plugin not configured)', 'coinbase-woocommerce'), 'error' ); 
+					} else { 
+						$woocommerce->add_error(__('Sorry, but there was an error processing your order. Please try again or try a different payment method. (plugin not configured)', 'coinbase-woocommerce'));
+					}
 					return;
 				}
 
@@ -213,7 +217,11 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
 				}
 				catch (Exception $e) {
 					$order->add_order_note(__('Error while processing coinbase payment:', 'coinbase-woocommerce') . ' ' . var_export($e, TRUE));
-					$woocommerce->add_error(__('Sorry, but there was an error processing your order. Please try again or try a different payment method.', 'coinbase-woocommerce'));
+					if ( version_compare( $woocommerce->version, '2.1', '>=' ) ) { 
+						wc_add_notice(__('Sorry, but there was an error processing your order. Please try again or try a different payment method.', 'coinbase-woocommerce'), 'error' );
+					} else { 
+						$woocommerce->add_error(__('Sorry, but there was an error processing your order. Please try again or try a different payment method.', 'coinbase-woocommerce'));
+					}
 					return;
 				}
 


### PR DESCRIPTION
Since woocommerce 2.1 the old notice system has been removed this adds support for the new [wc_add_notice] (http://docs.woothemes.com/wc-apidocs/function-wc_add_notice.html) while preserving support for older versions of woocommerce. 

